### PR TITLE
fix: delete specified ebtables chain.

### DIFF
--- a/ebtables/command.go
+++ b/ebtables/command.go
@@ -640,11 +640,12 @@ type DeleteChain struct {
 	chainName string
 }
 
-func newDeleteChain() *DeleteChain {
+func newDeleteChain(chainName string) *DeleteChain {
 	command := &DeleteChain{
 		baseCommand: &baseCommand{
 			commandType: CommandTypeDeleteChain,
 		},
+		chainName: chainName,
 	}
 	command.setChild(command)
 	return command

--- a/ebtables/end.go
+++ b/ebtables/end.go
@@ -308,7 +308,7 @@ func (ebtables *EBTables) DeleteChain() error {
 
 	for _, table := range tables {
 		newebtables.Table(table)
-		command := newDeleteChain()
+		command := newDeleteChain(newebtables.statement.chain)
 		newebtables.statement.command = command
 		if newebtables.dr {
 			newebtables.dryrun()


### PR DESCRIPTION
Current code logic not specified delete chain name, so it can't delete defined chain.

Here is my simple test code:
```golang
func TestCreateEbtablesChain(t *testing.T) {
	tables := ebtables.NewEBTables()
	if err := tables.NewChain("test-chain"); err != nil {
		t.Fatalf("failed to create chain: %v", err)
	}
	chain := ebtables.ChainTypeUserDefined
	chain.SetName("test-chain")
	tables.Table(ebtables.TableTypeFilter).Chain(chain).Policy(ebtables.TargetTypeDrop)
}

func TestDeleteEbtablesChain(t *testing.T) {
	chain := ebtables.ChainTypeUserDefined
	chain.SetName("test-chain")
	if err := ebtables.NewEBTables().Table(ebtables.TableTypeFilter).Chain(chain).DeleteChain(); err != nil {
		t.Fatalf("failed to delete chain: %v", err)
	}
}
```